### PR TITLE
Fixed runner if  package-lock.json is not present

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -34,7 +34,12 @@ jobs:
 
       - name: Install dependencies
         working-directory: docs
-        run: npm ci
+        run: |
+          if [ -f package-lock.json ]; then
+            npm ci
+          else
+            npm install
+          fi
 
       - name: Build site
         working-directory: docs


### PR DESCRIPTION
## Description

Fixed an issue in the CI runner where the workflow would fail if `package-lock.json` was not present.  
The update adds a conditional check to handle cases where the lock file is missing, ensuring that the build and deployment steps continue smoothly.

## Type of change

- [x] fix
- [ ] feat
- [ ] docs
- [ ] chore
- [ ] refactor
- [ ] test

## Checklist

- [x] I have read the CONTRIBUTING guide
- [x] My commits follow Conventional Commits
- [x] My commits are GPG-signed
- [ ] I added/updated tests (if applicable)
- [x] I updated documentation (if applicable)

## Screenshots/Logs

N/A — The runner now executes successfully even when `package-lock.json` is missing.
