### PR TITLE
Fixed all dead-links

### DIFF
--- a/docs/components/kafka-manager.md
+++ b/docs/components/kafka-manager.md
@@ -246,6 +246,6 @@ The orchestrator service integrates with Kafka Manager as follows:
 
 ## Related Documentation
 
-- [Kafka Setup](/setup/kafka) - Kafka configuration and setup
+- [Kafka Setup](/setup-guides/self-host/kafka-setup) - Kafka configuration and setup
 - [Architecture Overview](/architecture-overview) - Complete system architecture
 

--- a/docs/components/kafka.md
+++ b/docs/components/kafka.md
@@ -90,7 +90,7 @@ kafka-configs.sh --alter \
 
 ## Configuration
 
-See the [Kafka Setup Guide](/setup/kafka) for detailed configuration instructions.
+See the [Kafka Setup Guide](/setup-guides/self-host/kafka-setup) for detailed configuration instructions.
 
 **Important**: We require **Zookeeper-based Kafka** because we use Kafka Manager APIs for metrics, which require Zookeeper.
 
@@ -104,8 +104,7 @@ See the [Kafka Setup Guide](/setup/kafka) for detailed configuration instruction
 
 - **[Vector](/components/vector)** - Sends logs to Kafka
 - **[Kafka Manager](/components/kafka-manager)** - Monitors and manages Kafka cluster
-- **[Apache Spark](/components/spark)** - Consumes logs from Kafka
-- **[Orchestrator Service](/components/orchestrator)** - Automatically scales Kafka partitions
+
 
 ## Verification
 

--- a/docs/components/orchestrator.md
+++ b/docs/components/orchestrator.md
@@ -1,0 +1,23 @@
+---
+title: Orchestrator Service
+---
+
+# Orchestrator Service
+
+The Orchestrator Service standardizes tags, builds metadata for Grafana dropdowns, and automates Kafka partition scaling based on throughput.
+
+## Responsibilities
+
+- Aggregate and standardize source tags: `type`, `env`, `service_name`
+- Periodically fetch S3/Athena partition keys and persist metadata in the database
+- Expose APIs used by Grafana to populate dashboard variables
+- Monitor Kafka topic message rates and scale partitions when thresholds are exceeded
+
+## Data flow
+
+1. OTEL Collector adds tags to logs
+2. Vector converts tags to fields and sends to Kafka
+3. Spark writes partitioned datasets to S3
+4. Orchestrator derives partition metadata and serves it via APIs
+
+

--- a/docs/setup-guides/docker/index.md
+++ b/docs/setup-guides/docker/index.md
@@ -1,0 +1,11 @@
+---
+title: Docker Setup
+---
+
+# Docker Setup
+
+This section will contain Docker-based setup instructions for Logwise.
+
+Coming soon.
+
+

--- a/docs/setup-guides/self-host/grafana-setup.md
+++ b/docs/setup-guides/self-host/grafana-setup.md
@@ -24,7 +24,7 @@ docker run -d \
   grafana/grafana:latest
 ```
 
-Access Grafana at http://localhost:3000 (default login: `admin` / `admin`).
+Access Grafana at `http://localhost:3000` (default login: `admin` / `admin`).
 
 Alternative installs: refer to Grafana docs for Linux packages or Kubernetes Helm charts.
 

--- a/docs/what-is-logwise.md
+++ b/docs/what-is-logwise.md
@@ -67,8 +67,8 @@ Logwise is ideal for:
 Ready to get started with Logwise? Check out:
 
 - [Architecture Overview](/architecture-overview) - Understand the system design
-- [Docker Setup Guide](/setup/docker) - Quick start with Docker
-- [Self-Host Setup Guide](/setup/self-host) - Deploy on your infrastructure
+- [Docker Setup Guide](/setup-guides/docker/) - Quick start with Docker
+- [Self-Host Setup Guide](/setup-guides/self-host/grafana-setup) - Deploy on your infrastructure
 - [Component Documentation](/components/vector) - Detailed component guides
 
 


### PR DESCRIPTION
## Description

Fixed all dead links in the documentation deployment pipeline that were preventing the end-to-end (E2E) docs runner from executing successfully.  
This ensures that the documentation deployment process completes without broken references or link-related build failures.

## Type of change

- [x] fix
- [ ] feat
- [ ] docs
- [ ] chore
- [ ] refactor
- [ ] test

## Screenshots/Logs

N/A — Verified that the E2E documentation deployment runner now executes successfully with no dead links.
