### PR TITLE
added spark worker cleanup every 4 hours

### DIFF
--- a/spark/src/main/resources/application-config/application.conf
+++ b/spark/src/main/resources/application-config/application.conf
@@ -56,6 +56,11 @@ sparkConfig."spark.streaming.backpressure.enabled" = true
 sparkConfig."spark.streaming.concurrentJobs" = 4
 sparkConfig."spark.kafka.consumer.cache.capacity" = 256
 
+// spark worker cleanup config
+sparkConfig."spark.worker.cleanup.enabled" = true
+sparkConfig."spark.worker.cleanup.interval" = 3600
+sparkConfig."spark.worker.cleanup.appDataTtl" = 14400
+
 // spark hadoop config
 sparkConfig."spark.hadoop.fs.s3a.committer.magic.enabled" = true
 sparkConfig."spark.hadoop.fs.s3a.committer.name" = magic


### PR DESCRIPTION
## Summary  
Configure Spark worker with:

   ```properties
   spark.worker.cleanup.enabled=true
   spark.worker.cleanup.interval=3600
   spark.worker.cleanup.appDataTtl=14400
  ``` 
TTL can be tuned based on operational needs; 4 hours is sufficient for current workload.

## Type  
- [ ] Feature  
- [x] Fix  
- [ ] Docs  
- [ ] Refactor  

## Notes  
Add any screenshots, logs, or extra context if needed.
