### PR TITLE
Fix/spark worker cleanup

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -220,8 +220,9 @@ services:
       - SPARK_MODE=worker
       - SPARK_WORKER_MEMORY=2g
       - SPARK_WORKER_CORES=2
+      - SPARK_WORKER_OPTS=-Dspark.worker.memory=2048m -Dspark.shuffle.service.enabled=true -Dspark.worker.cleanup.enabled=true -Dspark.worker.cleanup.interval=3600 -Dspark.worker.cleanup.appDataTtl=3600
     command: ["bash", "-lc", 
-      "mkdir -p /opt/spark/logs && SPARK_WORKER_OPTS='-Dspark.worker.memory=2048m -Dspark.shuffle.service.enabled=true' /opt/spark/bin/spark-class org.apache.spark.deploy.worker.Worker spark://spark-master:7077 --webui-port 8081 --memory 2048m --cores 2"]
+      "mkdir -p /opt/spark/logs && /opt/spark/bin/spark-class org.apache.spark.deploy.worker.Worker spark://spark-master:7077 --webui-port 8081 --memory 2048m --cores 2"]
     networks:
       - lc_net
     volumes:
@@ -249,8 +250,9 @@ services:
       - SPARK_MODE=worker
       - SPARK_WORKER_MEMORY=2g
       - SPARK_WORKER_CORES=2
+      - SPARK_WORKER_OPTS=-Dspark.worker.memory=2048m -Dspark.shuffle.service.enabled=true -Dspark.worker.cleanup.enabled=true -Dspark.worker.cleanup.interval=3600 -Dspark.worker.cleanup.appDataTtl=3600
     command: ["bash", "-lc",
-              "mkdir -p /opt/spark/logs && SPARK_WORKER_WEBUI_PORT=8082 && SPARK_WORKER_OPTS='-Dspark.worker.memory=2048m -Dspark.shuffle.service.enabled=true' /opt/spark/bin/spark-class org.apache.spark.deploy.worker.Worker spark://spark-master:7077 --webui-port 8082 --memory 2048m --cores 2"]
+              "mkdir -p /opt/spark/logs && SPARK_WORKER_WEBUI_PORT=8082 && /opt/spark/bin/spark-class org.apache.spark.deploy.worker.Worker spark://spark-master:7077 --webui-port 8082 --memory 2048m --cores 2"]
     networks:
       - lc_net
     volumes:

--- a/spark/docker/Dockerfile
+++ b/spark/docker/Dockerfile
@@ -149,6 +149,9 @@ RUN echo "Setting up directories and permissions..." && \
     mkdir -p ${SPARK_HOME}/conf && \
     echo "spark.worker.memory 2048m" > ${SPARK_HOME}/conf/spark-defaults.conf && \
     echo "spark.worker.cores 2" >> ${SPARK_HOME}/conf/spark-defaults.conf && \
+    echo "spark.worker.cleanup.enabled true" >> ${SPARK_HOME}/conf/spark-defaults.conf && \
+    echo "spark.worker.cleanup.interval 3600" >> ${SPARK_HOME}/conf/spark-defaults.conf && \
+    echo "spark.worker.cleanup.appDataTtl 3600" >> ${SPARK_HOME}/conf/spark-defaults.conf && \
     chown -R spark:spark ${SPARK_HOME}/conf && \
     # Create app directory for JAR files
     mkdir -p /opt/app && \

--- a/spark/src/main/resources/application-config/application.conf
+++ b/spark/src/main/resources/application-config/application.conf
@@ -56,11 +56,6 @@ sparkConfig."spark.streaming.backpressure.enabled" = true
 sparkConfig."spark.streaming.concurrentJobs" = 4
 sparkConfig."spark.kafka.consumer.cache.capacity" = 256
 
-// spark worker cleanup config
-sparkConfig."spark.worker.cleanup.enabled" = true
-sparkConfig."spark.worker.cleanup.interval" = 3600
-sparkConfig."spark.worker.cleanup.appDataTtl" = 14400
-
 // spark hadoop config
 sparkConfig."spark.hadoop.fs.s3a.committer.magic.enabled" = true
 sparkConfig."spark.hadoop.fs.s3a.committer.name" = magic


### PR DESCRIPTION
## Summary  
Moved clean config from job submit level config to core worker config which is default for spark. Job level config doesn't use respective config for spark workers jobs history logs.

## Type  
- [ ] Feature  
- [x] Fix  
- [ ] Docs  
- [ ] Refactor  

## Notes  
Add any screenshots, logs, or extra context if needed.
